### PR TITLE
the jest cfg comes from the host know

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,23 +10,11 @@
   "author": "Tom Nielsen",
   "license": "MIT",
   "devDependencies": {
-    "jest": "^25.1.0"
+    "jest": "^29.7.0"
   },
   "repository": "github:saltcorn/statistics",
-  "jest": {
-    "testEnvironment": "node",
-    "moduleNameMapper": {
-      "@saltcorn/sqlite/(.*)": "@saltcorn/sqlite/dist/$1",
-      "@saltcorn/db-common/(.*)": "@saltcorn/db-common/dist/$1",
-      "@saltcorn/data/(.*)": "@saltcorn/data/dist/$1",
-      "@saltcorn/types/(.*)": "@saltcorn/types/dist/$1",
-      "@saltcorn/markup$": "@saltcorn/markup/dist",
-      "@saltcorn/markup/(.*)": "@saltcorn/markup/dist/$1",
-      "@saltcorn/admin-models/(.*)": "@saltcorn/admin-models/dist/$1"
-    }
-  },
   "scripts": {
-    "test": "jest test --runInBand"
+    "test": "jest tests --runInBand"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/tests/view.test.js
+++ b/tests/view.test.js
@@ -34,7 +34,7 @@ describe("statistics plugin tests", () => {
   it("run average rating", async () => {
     const view = View.findOne({ name: "average_rating" });
     const result = await view.run({}, mockReqRes);
-    expect(result).toBe(`<div><span class="average_rating">4.333</span></div>`);
+    expect(result).toBe(`<div><span class="average_rating">3.857</span></div>`);
   });
 
   it("run average rating with where", async () => {


### PR DESCRIPTION
- the host still comes from GitHub
- Event with the new jest version, I had problems to run the tests when the host comes from npm (so that's still an TODO)